### PR TITLE
`make compose-test` and `make k8s-test` more robust and valuable (#54)

### DIFF
--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -12,8 +12,9 @@ nodes:
     protocol: TCP
 EOF
 
+GATEWAY_API_VERSION=$(curl -sL https://api.github.com/repos/kubernetes-sigs/gateway-api/releases/latest | jq -r .tag_name)
 kubectl apply \
-    -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
+    -f https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml
 
 helm install ngf oci://ghcr.io/nginxinc/charts/nginx-gateway-fabric \
     --create-namespace \
@@ -32,4 +33,7 @@ spec:
   - name: http
     port: 80
     protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
 EOF


### PR DESCRIPTION
* Test curl output

* Fix --override-property

* Improve tests

* More logs in tests

* logs before curl in tests

* kubectl wait -l app.kubernetes.io/managed-by=score-k8s

* latest gateway api version + gateway across namespaces