### PR TITLE
Update `dependabot.yml` - do not bump major version of `node` container image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: 'node'
+        update-types: ['version-update:semver-major']
     groups:
       ci:
         patterns:


### PR DESCRIPTION
Update `dependabot.yml` - do not bump major version of `node` container image