### PR TITLE
`node:22-alpine` --> `alpine`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,19 +21,19 @@ FROM node:22-alpine@sha256:41e4389f3d988d2ed55392df4db1420ad048ae53324a8e2b7c6d1
 ENV PYTHON=/usr/bin/python3
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    --mount=type=cache,target=/var/lib/apk,sharing=locked \
     apk update && \
     apk add python3 g++ make && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apk/lists/*
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    --mount=type=cache,target=/var/lib/apk,sharing=locked \
     apk update && \
     apk add sqlite-dev && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apk/lists/*
 
 USER node
 WORKDIR /app
@@ -53,27 +53,28 @@ RUN mkdir packages/backend/dist/skeleton packages/backend/dist/bundle \
     && tar xzf packages/backend/dist/bundle.tar.gz -C packages/backend/dist/bundle
 
 # Stage 3 - Build the actual backend image and install production dependencies
-FROM node:22-alpine@sha256:41e4389f3d988d2ed55392df4db1420ad048ae53324a8e2b7c6d19508288107e
+FROM alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
 
 # Set Python interpreter for `node-gyp` to use
 ENV PYTHON=/usr/bin/python3
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    --mount=type=cache,target=/var/lib/apk,sharing=locked \
     apk update && \
-    apk add python3 g++ make && \
-    rm -rf /var/lib/apt/lists/*
+    apk add nodejs yarn python3 g++ make && \
+    rm -rf /var/lib/apk/lists/*
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    --mount=type=cache,target=/var/lib/apk,sharing=locked \
     apk update && \
     apk add sqlite-dev && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apk/lists/*
 
 # From here on we use the least-privileged `node` user to run the backend.
+RUN addgroup -S node && adduser -S node -G node
 USER node
 
 # This should create the app dir as `node`.


### PR DESCRIPTION
`node:22-alpine` --> `alpine`

Like done there:
- https://github.com/finos/traderX/pull/258
- https://github.com/GoogleCloudPlatform/microservices-demo/pull/2538

Container image size on disk:
- Before: `923MB`
- After: `846MB` --> `-77MB` saved!

Number of packages via syft:
- Before: 1584
```none
 ✔ Cataloged contents 
   ├── ✔ Packages                        [1,584 packages]  
   ├── ✔ Executables                     [172 executables]  
   ├── ✔ File metadata                   [4,955 locations]  
   └── ✔ File digests                    [4,955 files]
```

- After: 1375 (-209 saved!)
```none
 ✔ Cataloged contents
   ├── ✔ Packages                        [1,375 packages]  
   ├── ✔ Executables                     [186 executables]  
   ├── ✔ File metadata                   [4,911 locations]  
   └── ✔ File digests                    [4,911 files] 
```