### PR TITLE
Fix CVE with `prismjs` `>=1.30.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "jsonpath-plus": ">=10.3.0",
-    "tough-cookie": ">=4.1.3"
+    "tough-cookie": ">=4.1.3",
+    "prismjs": ">=1.30.0"
   },
   "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -28148,17 +28148,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:^1.27.0":
+"prismjs@npm:>=1.30.0":
   version: 1.30.0
   resolution: "prismjs@npm:1.30.0"
   checksum: 10c0/f56205bfd58ef71ccfcbcb691fd0eb84adc96c6ff21b0b69fc6fdcf02be42d6ef972ba4aed60466310de3d67733f6a746f89f2fb79c00bf217406d465b3e8f23
-  languageName: node
-  linkType: hard
-
-"prismjs@npm:~1.27.0":
-  version: 1.27.0
-  resolution: "prismjs@npm:1.27.0"
-  checksum: 10c0/841cbf53e837a42df9155c5ce1be52c4a0a8967ac916b52a27d066181a3578186c634e52d06d0547fb62b65c486b99b95f826dd54966619f9721b884f486b498
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix CVE with `prismjs` `>=1.30.0`, like done with https://github.com/mathieu-benoit/deploy-backstage-with-score/pull/68, fixing https://github.com/mathieu-benoit/deploy-backstage-with-score/security/dependabot/19.