### PR TITLE
Update Backstage's `catalog-info.yaml` with explicit dependency between `frontend` and `backend` + `shared.dns`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ run-light:
 .score-compose/state.yaml:
 	score-compose init \
 		--no-sample \
+		--provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/service/score-compose/10-service.provisioners.yaml \
 		--provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/dns/score-compose/10-dns-with-url.provisioners.yaml
 
 compose.yaml: score-backend.yaml score-frontend.yaml .score-compose/state.yaml Makefile
@@ -101,6 +102,7 @@ NAMESPACE ?= default
 .score-k8s/state.yaml:
 	score-k8s init \
 		--no-sample \
+		--provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/service/score-k8s/10-service.provisioners.yaml \
 		--provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/dns/score-k8s/10-dns-with-url.provisioners.yaml
 
 manifests.yaml: score-backend.yaml score-frontend.yaml .score-k8s/state.yaml Makefile

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -27,34 +27,12 @@ metadata:
     title: backend
 spec:
     dependsOn:
-        - resource:backstage-backend-dns
+        - resource:shared-dns
         - resource:backstage-backend-pg
     lifecycle: experimental
     owner: user:guest
     system: backstage
     type: service
----
-apiVersion: backstage.io/v1alpha1
-kind: Resource
-metadata:
-    description: 'dns (type: dns) of backend'
-    name: backstage-backend-dns
-    title: dns
-spec:
-    owner: user:guest
-    system: backstage
-    type: dns
----
-apiVersion: backstage.io/v1alpha1
-kind: Resource
-metadata:
-    description: 'pg (type: postgres-instance) of backend'
-    name: backstage-backend-pg
-    title: pg
-spec:
-    owner: user:guest
-    system: backstage
-    type: postgres-instance
 ---
 apiVersion: backstage.io/v1alpha1
 kind: Component
@@ -70,7 +48,8 @@ metadata:
     title: frontend
 spec:
     dependsOn:
-        - resource:backstage-frontend-dns
+        - component:backstage-backend
+        - resource:shared-dns
     lifecycle: experimental
     owner: user:guest
     system: backstage
@@ -79,8 +58,30 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-    description: 'dns (type: dns) of frontend'
-    name: backstage-frontend-dns
+    description: backstage-backend-pg
+    name: backstage-backend-pg
+    title: pg
+spec:
+    owner: user:guest
+    system: backstage
+    type: postgres-instance
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+    description: backstage-frontend-backend
+    name: backstage-frontend-backend
+    title: backend
+spec:
+    owner: user:guest
+    system: backstage
+    type: service
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+    description: shared-dns
+    name: shared-dns
     title: dns
 spec:
     owner: user:guest

--- a/score-frontend.yaml
+++ b/score-frontend.yaml
@@ -21,6 +21,8 @@ service:
       port: 3000
       targetPort: 8080
 resources:
+  backend:
+    type: service
   dns:
     type: dns
     id: dns


### PR DESCRIPTION
```bash
score-k8s init \
  --provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/service/score-k8s/10-service.provisioners.yaml \
  --provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/dns/score-k8s/10-dns-with-url.provisioners.yaml \
  --patch-templates ./score-k8s/backstage-catalog-entities.tpl

score-k8s generate score-backend.yaml \
  --namespace backstage \
  --image ghcr.io/mathieu-benoit/backstage-frontend:latest \
  --output catalog-info.yaml
score-k8s generate score-frontend.yaml \
  --namespace backstage \
  --generate-namespace \
  --image ghcr.io/mathieu-benoit/backstage-backend:latest \
  --output catalog-info.yaml

sed 's,$GITHUB_REPO,mathieu-benoit/deploy-backstage-with-score,g' -i catalog-info.yaml
```