### PR TITLE
`emptyDir` for `/tmp` for `backend`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-and-run-light:
 		--patch-templates https://raw.githubusercontent.com/score-spec/community-patchers/refs/heads/main/score-compose/unprivileged.tpl \
 		--provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/service/score-compose/10-service.provisioners.yaml
 	score-compose generate score-backend.light.yaml \
-    		--build 'backend={"context":".","dockerfile":"Dockerfile","tags":["backend:local"]}'
+    		--build 'backend={"context":".","tags":["backend:local"]}'
 	score-compose generate score-frontend.light.yaml \
 		--build 'frontend={"context":".","dockerfile":"Dockerfile.frontend","tags":["frontend:local"]}' \
 		--override-property containers.frontend.variables.APP_CONFIG_app_title="Hello, Compose!" \

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Then navigate to http://localhost:3000.
 ## With `score-compose`
 
 ```bash
-score-compose init --no-sample
+score-compose init --no-sample 	\
+    --patch-templates https://raw.githubusercontent.com/score-spec/community-patchers/refs/heads/main/score-compose/unprivileged.tpl \
+    --provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/service/score-compose/10-service.provisioners.yaml
 ```
 
 ### By building a new container image

--- a/README.md
+++ b/README.md
@@ -23,18 +23,17 @@ Then navigate to http://localhost:3000.
 
 ```sh
 docker image build -t backstage-backend:local .
-
 docker run -d \
     -u 65532 \
     --cap-drop=ALL \
     --read-only \
+    --tmpfs /tmp \
     -e APP_CONFIG_backend_database_client='better-sqlite3' \
     -e APP_CONFIG_backend_database_connection=':memory:' \
     -p 7007:7007 \
     backstage-backend:local
 
 docker image build -f Dockerfile.frontend -t backstage-frontend:local .
-
 docker run -d \
     -u 65532 \
     --cap-drop=ALL \
@@ -49,6 +48,7 @@ docker run -d \
     -u 65532 \
     --cap-drop=ALL \
     --read-only \
+    --tmpfs /tmp \
     -e APP_CONFIG_backend_database_client='better-sqlite3' \
     -e APP_CONFIG_backend_database_connection=':memory:' \
     -p 7007:7007 \

--- a/score-backend.light.yaml
+++ b/score-backend.light.yaml
@@ -18,8 +18,15 @@ containers:
       APP_CONFIG_auth_providers_guest_dangerouslyAllowOutsideDevelopment: "true"
       APP_CONFIG_backend_cors_origin: http://localhost:3000
       APP_CONFIG_techRadar_url: https://github.com/mathieu-benoit/humanitec-ref-arch/blob/main/tech-radar.json
+    volumes:
+      /tmp:
+        source: ${resources.tmp-dir}
+        readOnly: false
 service:
   ports:
     tcp:
       port: 7007
       targetPort: 7007
+resources:
+  tmp-dir:
+    type: volume

--- a/score-backend.yaml
+++ b/score-backend.yaml
@@ -30,6 +30,10 @@ containers:
       httpGet:
         path: /.backstage/health/v1/readiness
         port: 7007
+    volumes:
+      /tmp:
+        source: ${resources.tmp-dir}
+        readOnly: false
 service:
   ports:
     tcp:
@@ -47,3 +51,5 @@ resources:
       host: ${resources.dns.host}
       path: /api
       port: 7007
+  tmp-dir:
+    type: volume


### PR DESCRIPTION
`emptyDir` for `/tmp` for `backend`, otherwise getting this error when using the scaffolder:
```
ENOENT: no such file or directory, mkdir '/tmp/30f72973-9d18-4177-81e5-6a015d112428'
```
<img width="1901" height="330" alt="image" src="https://github.com/user-attachments/assets/9c7c117c-9a28-4944-a506-b07ed8c9ebd3" />
